### PR TITLE
feat: disable logs when running unit tests

### DIFF
--- a/components/definition/definition.go
+++ b/components/definition/definition.go
@@ -80,7 +80,8 @@ type ExternalServiceEntry interface {
 
 // Tests gathers unit tests related options.
 type Tests struct {
-	ExecuteLifecycle bool `toml:"execute_lifecycle"`
+	ExecuteLifecycle   bool  `toml:"execute_lifecycle"`
+	DiscardLogMessages *bool `toml:"discard_log_messages"`
 }
 
 // New creates a new Definitions structure initializing the service

--- a/service.go
+++ b/service.go
@@ -86,9 +86,16 @@ func initService(opt *options.NewServiceOptions) (*Service, error) {
 		return nil, err
 	}
 
+	// By default, we always discard log messages when running unit tests,
+	// but this behavior can be changed using service definitions.
+	discardMessages := envs.DeploymentEnv() == definition.ServiceDeploy_Test
+	if discardMessages && defs.Tests.DiscardLogMessages != nil {
+		discardMessages = *defs.Tests.DiscardLogMessages
+	}
+
 	// Initialize the service logger system.
 	serviceLogger := mlogger.New(mlogger.Options{
-		LogOnlyFatalLevel:      envs.DeploymentEnv() == definition.ServiceDeploy_Test,
+		DiscardMessages:        discardMessages,
 		DisableErrorStacktrace: !defs.Log.ErrorStacktrace,
 		FixedAttributes: map[string]string{
 			"service.name":    defs.ServiceName().String(),


### PR DESCRIPTION
- Adding new definition that allows enable/disable log messages when running unit tests. The default is always hide these messages.